### PR TITLE
Fix bug in start_archiving

### DIFF
--- a/PyTangoArchiving/hdbpp/config.py
+++ b/PyTangoArchiving/hdbpp/config.py
@@ -210,12 +210,12 @@ class HDBpp(ArchivingDB,SingletonMap):
         try:
           self.info('start_archiving(%s)'%attribute)
           d = self.get_manager()
-          attribute = self.is_attribute_archived(attribute)
-          if not attribute:
+          fullname = self.is_attribute_archived(attribute)
+          if not fullname:
             self.add_attribute(attribute,*args,**kwargs)
             time.sleep(10.)
-            attribute = self.is_attribute_archived(attribute)
-          d.AttributeStart(attribute)
+            fullname = self.is_attribute_archived(attribute)
+          d.AttributeStart(fullname)
           return True
         except Exception,e:
           self.error('start_archiving(%s): %s'%(attribute,traceback.format_exc().replace('\n','')))


### PR DESCRIPTION
start_archiving fails if it is trying to archive an unregistered attribute.
The method  seems to be overwrite the given name by 
"tango://$HOST_NAME/False".

Fix it, using two variables to avoid overwrite the device name.