### PR TITLE
[WIP] Add missing ui file

### DIFF
--- a/PyTangoArchiving/snap.py
+++ b/PyTangoArchiving/snap.py
@@ -71,7 +71,8 @@ class SnapAPI(Logger,Singleton):
 
     __instantiated__ = 0
 
-    def __init__(self,user='browser',passwd='browser',api=None,SINGLETON=True,load=True):
+    #def __init__(self,user='browser',passwd='browser',api=None,SINGLETON=True,load=True):
+    def __init__(self,user='snaparchiver',passwd='snaparchiver',api=None,SINGLETON=True,load=True):
         """ The SnapAPI is a Singleton object; is instantiated only one time
         @param[in] api An ArchivingAPI object is required.
         """
@@ -97,7 +98,7 @@ class SnapAPI(Logger,Singleton):
             passwd=self.api.tango.get_class_property('SnapArchiver',['DbPassword'])['DbPassword'][0]
             print 'Connecting to %s as %s ...' % (host,user)
             self.set_db_config(api,host,user,passwd)
-          
+
             try:
                 if load: self.load_contexts()
             except:
@@ -113,6 +114,7 @@ class SnapAPI(Logger,Singleton):
 
     def set_db_config(self,api,host,user,passwd):
         self.db=SnapDB(api,host=host,user=user,passwd=passwd)
+        print 'Done'
 
     ## @name Get methods
     # @{
@@ -657,7 +659,7 @@ class SnapDB(FriendlyDB,Singleton):
         """SnapDB Singleton creator
         @param api it links the SnapDB object to its associated SnapAPI (unneeded?)
         """
-        print 'Creating SnapDB object ... (%s,%s,%s,%s,%s)' % (api,host,user,passwd,db_name)
+        print 'Creating SnapDB object ... (%s,%s,%s,%s,%s)' % ('',host,user,passwd,db_name)
         self._api=api if api else None
         FriendlyDB.__init__(self,db_name,host or (api and api.arch_host) or 'localhost',user,passwd)
         assert hasattr(self,'db'),'SnapDB_UnableToCreateConnection'

--- a/PyTangoArchiving/widget/snaps/contexttoolbar.py
+++ b/PyTangoArchiving/widget/snaps/contexttoolbar.py
@@ -1,4 +1,7 @@
-from PyQt4 import Qt
+try:
+    from taurus.external.qt import Qt
+except:
+    from PyQt4 import Qt
 from snapdialogs import SnapSaver, SnapLoader
 
 

--- a/PyTangoArchiving/widget/snaps/snapbutton.py
+++ b/PyTangoArchiving/widget/snaps/snapbutton.py
@@ -27,7 +27,10 @@
 ###########################################################################
 
 import sys, taurus
-from PyQt4 import Qt, QtGui, QtCore
+try:
+    from taurus.external.qt import Qt, QtGui, QtCore
+except:
+    from PyQt4 import Qt, QtGui, QtCore
 from taurus.qt.qtgui import container
 from taurus.qt.qtgui.panel import TaurusForm
 from PyTangoArchiving import SnapAPI

--- a/PyTangoArchiving/widget/snaps/snapdialogs.py
+++ b/PyTangoArchiving/widget/snaps/snapdialogs.py
@@ -42,7 +42,8 @@ from taurus.qt.qtgui.application import TaurusApplication
 from taurus.qt.qtgui.container import TaurusWidget
 from taurus.qt.qtgui.button import TaurusLauncherButton
 from taurus.qt.qtgui.panel import TaurusValue,TaurusForm,DefaultTaurusValueCheckBox
-from PyTangoArchiving.widget.taurusattributechooser import TaurusAttributeChooser as AttrChooser
+#from PyTangoArchiving.widget.taurusattributechooser import TaurusAttributeChooser as AttrChooser
+from taurus.qt.qtgui.panel.taurusmodelchooser import TaurusModelChooser as AttrChooser
 from taurus.qt.qtgui.input import TaurusValueLineEdit
 from taurus.qt.qtgui.table import TaurusValuesTable
 from taurus.qt.qtgui.plot import TaurusPlot

--- a/PyTangoArchiving/widget/snaps/snaps.py
+++ b/PyTangoArchiving/widget/snaps/snaps.py
@@ -293,6 +293,7 @@ class SnapForm(Snap_Core_Ui_Form, SnapDialog):
         """
         #self.contextComboBox.blockSignals(True)
         #self.contextComboBox.clear()
+        contexts = None
         self._Form.setWindowTitle(QtGui.QApplication.translate("Form",'!'+str(os.getenv('TANGO_HOST')).split(':',1)[0]+' -> Snapshoting', None, QtGui.QApplication.UnicodeUTF8))
         try:
             if attrlist:
@@ -309,12 +310,13 @@ class SnapForm(Snap_Core_Ui_Form, SnapDialog):
                                     "Could not talk with SnapManager DS.<br>" + \
                                     "Please check if DS is running.")
 
-        ctxs=sorted(contexts.values(), key=lambda s:s.name.lower())
-        for context in ctxs:
-            self.contextComboBox.addItem("%s [%d]" % (context.name, context.ID), Qt.QVariant(context.ID))
-        #self.contextComboBox.model().sort(0, Qt.Qt.AscendingOrder)
-        if sid>=0: self.listWidget.setCurrentRow(sid)
-        #self.contextComboBox.blockSignals(False)
+        if contexts is not None:
+            ctxs=sorted(contexts.values(), key=lambda s:s.name.lower())
+            for context in ctxs:
+                self.contextComboBox.addItem("%s [%d]" % (context.name, context.ID), Qt.QVariant(context.ID))
+            #self.contextComboBox.model().sort(0, Qt.Qt.AscendingOrder)
+            if sid>=0: self.listWidget.setCurrentRow(sid)
+            #self.contextComboBox.blockSignals(False)
         
     def getCurrentSnap(self):
         """

--- a/PyTangoArchiving/widget/snaps/toolbar.py
+++ b/PyTangoArchiving/widget/snaps/toolbar.py
@@ -1,5 +1,8 @@
 import sys, taurus
-from PyQt4 import Qt, QtGui, QtCore
+try:
+    from taurus.external.qt import Qt, QtGui, QtCore
+except:
+    from PyQt4 import Qt, QtGui, QtCore
 from taurus.qt.qtgui import container
 from taurus.qt.qtgui.panel import TaurusForm
 from PyTangoArchiving import SnapAPI

--- a/PyTangoArchiving/widget/snaps/ui/core.py
+++ b/PyTangoArchiving/widget/snaps/ui/core.py
@@ -7,7 +7,10 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt4 import QtCore, QtGui, Qt
+try:
+    from taurus.external.qt import Qt, QtCore, QtGui
+except:
+    from PyQt4 import QtCore, QtGui, Qt
 import taurus
 from taurus.qt.qtgui.panel import TaurusForm
 

--- a/PyTangoArchiving/widget/snaps/ui/diff.py
+++ b/PyTangoArchiving/widget/snaps/ui/diff.py
@@ -7,7 +7,10 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt4 import QtCore, QtGui
+try:
+    from taurus.external.qt import Qt, QtCore, QtGui
+except:
+    from PyQt4 import QtCore, QtGui
 
 class Diff_Ui_Form(object):
     def diffSetupUi(self, Form):

--- a/PyTangoArchiving/widget/snaps/ui/modify.py
+++ b/PyTangoArchiving/widget/snaps/ui/modify.py
@@ -2,6 +2,7 @@ import taurus, sys, traceback
 from taurus.external.qt import Qt, QtCore, QtGui
 from PyTangoArchiving import SnapAPI
 from PyTangoArchiving.widget.taurusattributechooser import TaurusAttributeChooser
+#from taurus.qt.qtgui.panel.taurusmodelchooser import TaurusModelChooser as TaurusAttributeChooser
 
 class ContextEditUi(object):
     def setupUi(self, Form):

--- a/PyTangoArchiving/widget/ui/TaurusAttributeChooser.ui
+++ b/PyTangoArchiving/widget/ui/TaurusAttributeChooser.ui
@@ -1,0 +1,246 @@
+<ui version="4.0" >
+ <class>AttrCh</class>
+ <widget class="QWidget" name="AttrCh" >
+  <property name="geometry" >
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>371</width>
+    <height>469</height>
+   </rect>
+  </property>
+  <property name="minimumSize" >
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle" >
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" >
+   <item>
+    <layout class="QHBoxLayout" >
+     <item>
+      <widget class="QLabel" name="label_1" >
+       <property name="minimumSize" >
+        <size>
+         <width>54</width>
+         <height>20</height>
+        </size>
+       </property>
+       <property name="whatsThis" >
+        <string>&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Enter here the path for search a device.&lt;/p>
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Format:&lt;/p>
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Domain/Family/Member&lt;/p>
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;/p>&lt;/body>&lt;/html></string>
+       </property>
+       <property name="text" >
+        <string>Enter a path:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEdit" >
+       <property name="sizePolicy" >
+        <sizepolicy vsizetype="Fixed" hsizetype="Expanding" >
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize" >
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" >
+     <item>
+      <layout class="QVBoxLayout" >
+       <item>
+        <widget class="QLabel" name="label_2" >
+         <property name="whatsThis" >
+          <string>&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">List of Devices.&lt;/p>&lt;/body>&lt;/html></string>
+         </property>
+         <property name="text" >
+          <string>Devices:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QListWidget" name="devList" >
+         <property name="minimumSize" >
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" >
+       <item>
+        <widget class="QLabel" name="label_3" >
+         <property name="whatsThis" >
+          <string>&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">List of the device attributes.&lt;/p>&lt;/body>&lt;/html></string>
+         </property>
+         <property name="text" >
+          <string>Attributes:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QListWidget" name="attrList" >
+         <property name="minimumSize" >
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="selectionMode" >
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" >
+     <item>
+      <spacer>
+       <property name="orientation" >
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" >
+        <size>
+         <width>51</width>
+         <height>23</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="addButton" >
+       <property name="toolTip" >
+        <string>&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:10pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Add selected attribute(s) from the &lt;span style=" font-style:italic;">Attribute List&lt;/span> to the &lt;span style=" font-style:italic;">Chosen Attributes&lt;/span>&lt;/p>&lt;/body>&lt;/html></string>
+       </property>
+       <property name="text" >
+        <string>Add</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="removeButton" >
+       <property name="toolTip" >
+        <string>&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:10pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Remove selected attribute(s) from the &lt;span style=" font-style:italic;">Chosen Attributes&lt;/span>&lt;/p>&lt;/body>&lt;/html></string>
+       </property>
+       <property name="text" >
+        <string>Remove</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="cancelButton" >
+       <property name="toolTip" >
+        <string>&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:10pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Clear the &lt;span style=" font-style:italic;">Chosen Attributes&lt;/span> list&lt;/p>&lt;/body>&lt;/html></string>
+       </property>
+       <property name="text" >
+        <string>Clear</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" >
+     <item>
+      <widget class="QLabel" name="label_4" >
+       <property name="minimumSize" >
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="whatsThis" >
+        <string>&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">List of all the attributes selected.&lt;/p>&lt;/body>&lt;/html></string>
+       </property>
+       <property name="text" >
+        <string>Chosen attributes:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QListWidget" name="final_List" >
+       <property name="minimumSize" >
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="selectionMode" >
+        <enum>QAbstractItemView::ExtendedSelection</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="updateButton" >
+       <property name="minimumSize" >
+        <size>
+         <width>75</width>
+         <height>41</height>
+        </size>
+       </property>
+       <property name="toolTip" >
+        <string>&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:10pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Update the attribute(s)&lt;/p>&lt;/body>&lt;/html></string>
+       </property>
+       <property name="whatsThis" >
+        <string>&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Update with the choosen attributes.&lt;/p>&lt;/body>&lt;/html></string>
+       </property>
+       <property name="text" >
+        <string>Apply</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This PR fixes the issue #6 by adding the missing ui file for the TaurusAttributeChooser widget.

It is marked as WIP because there are some customizations needed at MaxIV in order to make the snaps gui work, so it needs to be reviewed.

The TaurusAttributeChooser.ui was taken from here:
https://github.com/taurus-org/taurus/blob/f41b15a2cc26a299c0b69d0d088c0fd284346d7b/lib/taurus/qt/qtgui/panel/ui/TaurusAttributeChooser.ui
